### PR TITLE
Correct typo on the AzureAD not present warning

### DIFF
--- a/Office 365/Connect-Office365.ps1
+++ b/Office 365/Connect-Office365.ps1
@@ -225,7 +225,7 @@ https://docs.microsoft.com/en-us/powershell/exchange/exchange-online/connect-to-
 		Write-Host "Checking for AzureAD Module"
 		If ($null -eq (Get-Module -ListAvailable -Name "AzureAD"))
 		{
-			Write-Warning "SkypeOnlineConnector Module is not present!"
+			Write-Warning "AzureAD Module is not present!"
 			
 		}
 		Else


### PR DESCRIPTION
The Write-Warning on line 228 incorrectly warned that the Skype module wasn't present, when it should be referring to the AzureAD module.