### PR TITLE
Updated Write-Warning on the Skype module.

### DIFF
--- a/Office 365/Connect-Office365.ps1
+++ b/Office 365/Connect-Office365.ps1
@@ -106,7 +106,7 @@ function Connect-Office365
 			AzureAD {
 				If ($null -eq (Get-Module @getModuleSplat -Name "AzureAD"))
 				{
-					Write-Error "SkypeOnlineConnector Module is not present!"
+					Write-Error "AzureAD Module is not present!"
 					continue
 				}
 				Else


### PR DESCRIPTION
The Write-Warning on line 228 incorrectly warned that the Skype module wasn't present, when it should be referring to the AzureAD module.